### PR TITLE
Fix spiral task handling on mission abort

### DIFF
--- a/main.py
+++ b/main.py
@@ -154,10 +154,15 @@ async def abort_mission():
         global drone
         global spiral_task
         if spiral_task:
-                await asyncio.wait_for(
-                        spiral_task,
-                        timeout=10
-                )
+                spiral_task.cancel()
+                try:
+                        await asyncio.wait_for(spiral_task, timeout=10)
+                except asyncio.CancelledError:
+                        pass
+                except asyncio.TimeoutError:
+                        pass
+                finally:
+                        spiral_task = None
         await drone.action.return_to_launch()
         return {"status": "success"}
 


### PR DESCRIPTION
## Summary
- improve abort_mission by cancelling the spiral task before waiting

## Testing
- `python -m py_compile main.py drone_flight.py`

------
https://chatgpt.com/codex/tasks/task_e_685dbaf1ea98832f98cdea5dce27ce31